### PR TITLE
feat: add parsing of multiple problems in single file

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,27 @@
+from validateactions import cli
+import tempfile
+import os
+
+def test_run():
+    workflow = """
+name: test
+on: psuh
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          unknown_input: 'test'
+"""
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write(workflow)
+        tmp_path = tmp.name 
+
+    try:
+        cli.run(tmp_path)
+    finally:
+        os.remove(tmp_path)
+    # tokens = list(parser.tokenize(workflow))
+    assert None is None

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,4 +1,4 @@
-from validateactions import cli
+from validateactions import cli, linter
 import tempfile
 import os
 
@@ -27,8 +27,19 @@ jobs:
         tmp_path = tmp.name 
 
     try:
-        cli.run(tmp_path)
+        with open(tmp_path, 'r') as f:
+            problems = linter.run(f)
     finally:
         os.remove(tmp_path)
-    # tokens = list(parser.tokenize(workflow))
-    assert None is None
+    
+    sorted_problems = sorted(problems, key=lambda x: (x.line, x.column))
+
+    assert len(sorted_problems) == 5
+    rule_event = 'event-trigger'
+    rule_input = 'jobs-steps-uses'
+    assert sorted_problems[0].rule == rule_event
+    assert sorted_problems[1].rule == rule_event
+    assert sorted_problems[2].rule == rule_input
+    assert sorted_problems[2].level == 'warning'
+    assert sorted_problems[3].rule == rule_input
+    assert sorted_problems[4].rule == rule_input

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -3,13 +3,20 @@ import tempfile
 import os
 
 def test_run():
-    workflow = """
-name: test
-on: psuh
+    workflow = """name: test
+on:
+  pus:
+    branches: [ $default-branch ]
+  pullrequest:
+    branches: [ $default-branch ]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Notify Slack
+        uses: 8398a7/action-slack
+        with:
+          unknown_input: 'test'
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
         with:

--- a/tests/rules_test/event_trigger_test.py
+++ b/tests/rules_test/event_trigger_test.py
@@ -14,8 +14,11 @@ def test_no_on():
 name: test
 """
     workflow_tokens = list(yaml.parse(workflow, Loader=yaml.BaseLoader))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert isinstance(result, LintProblem)
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert len(result) == 1
+    assert isinstance(result[0], LintProblem)
+    assert result[0].rule == 'event-trigger'
 
 def test_single_event_correct():
     workflow ="""
@@ -23,8 +26,9 @@ name: test
 on: push
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert result is None
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert result == []
 
 
 def test_single_event_problem():
@@ -33,8 +37,11 @@ name: test
 on: ush
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert isinstance(result, LintProblem)
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert len(result) == 1
+    assert isinstance(result[0], LintProblem)
+    assert result[0].rule == 'event-trigger'
 
 def test_flow_sequence_correct():
     workflow ="""
@@ -42,8 +49,9 @@ name: test
 on: [push, pull_request]
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert result is None
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert result == []
 
 def test_flow_sequence_problem():
     workflow ="""
@@ -51,8 +59,11 @@ name: test
 on: [push, pull_equest]
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert isinstance(result, LintProblem)
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert len(result) == 1
+    assert isinstance(result[0], LintProblem)
+    assert result[0].rule == 'event-trigger'
 
 def test_block_sequence_correct():
     workflow ="""
@@ -62,8 +73,9 @@ on:
   - pull_request
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert result is None
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert result == []
 
 def test_block_sequence_problem():
     workflow ="""
@@ -73,8 +85,11 @@ on:
   - pul_request
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert isinstance(result, LintProblem)
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert len(result) == 1
+    assert isinstance(result[0], LintProblem)
+    assert result[0].rule == 'event-trigger'
 
 def test_block_mapping_correct():
     workflow ="""
@@ -86,8 +101,9 @@ on:
     branches: [ $default-branch ]
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert result is None
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert result == []
 
 def test_block_mapping_problem():
     workflow ="""
@@ -99,5 +115,8 @@ on:
     branches: [ $default-branch ]
 """
     workflow_tokens = list(parser.tokenize(workflow))
-    result = event_trigger.check(workflow_tokens, schema)
-    assert isinstance(result, LintProblem)
+    gen = event_trigger.check(workflow_tokens, schema)
+    result = list(gen)
+    assert len(result) == 1
+    assert isinstance(result[0], LintProblem)
+    assert result[0].rule == 'event-trigger'

--- a/validateactions/cli.py
+++ b/validateactions/cli.py
@@ -23,8 +23,10 @@ def run(file):
     except OSError as e:
         print(e, file=sys.stderr)
         sys.exit(-1)
+
+    sorted_problems = sorted(problems, key=lambda x: (x.line, x.column))
     
-    prob_level = show_problems(problems, file)
+    prob_level = show_problems(sorted_problems, file)
 
     if prob_level == validateactions.linter.PROBLEM_LEVELS['error']:
         return_code = 1

--- a/validateactions/cli.py
+++ b/validateactions/cli.py
@@ -1,4 +1,4 @@
-import linter
+import validateactions.linter
 import sys
 
 class Format:
@@ -15,20 +15,20 @@ class Format:
         if problem.rule:
             line += f'  \033[2m({problem.rule})\033[0m'
         return line
-    
+
 def run(file):
     try:
         with open(file, newline='') as f:
-            problems = linter.run(f)
+            problems = validateactions.linter.run(f)
     except OSError as e:
         print(e, file=sys.stderr)
         sys.exit(-1)
     
     prob_level = show_problems(problems, file)
 
-    if prob_level == linter.PROBLEM_LEVELS['error']:
+    if prob_level == validateactions.linter.PROBLEM_LEVELS['error']:
         return_code = 1
-    elif prob_level == linter.PROBLEM_LEVELS['warning']:
+    elif prob_level == validateactions.linter.PROBLEM_LEVELS['warning']:
         return_code = 2
     else:
         return_code = 0
@@ -42,7 +42,7 @@ def show_problems(problems, file):
     first = True
 
     for problem in problems:
-        max_level = max(max_level, linter.PROBLEM_LEVELS[problem.level])
+        max_level = max(max_level, validateactions.linter.PROBLEM_LEVELS[problem.level])
         if first:
             print(f'\033[4m{file}\033[0m')
             first = False

--- a/validateactions/linter.py
+++ b/validateactions/linter.py
@@ -47,7 +47,7 @@ def get_actions_error(buffer):
     tokens = list(parser.tokenize(buffer))
     schema = get_workflow_schema(SCHEMA_FILE)
     for rule in ACTIONS_ERROR_RULES:
-        yield rule.check(tokens, schema)
+        yield from rule.check(tokens, schema)
         
 def get_workflow_schema(file):
     with open(file) as f:

--- a/validateactions/linter.py
+++ b/validateactions/linter.py
@@ -1,10 +1,8 @@
 import yaml
-import parser
+import validateactions.parser as parser
 import json
-import rules
-from lint_problem import LintProblem
-import rules.event_trigger
-import validateactions.rules.jobs_steps_uses
+import validateactions.rules as rules
+from validateactions.lint_problem import LintProblem
 
 PROBLEM_LEVELS = {
     0: None,
@@ -21,16 +19,12 @@ def run(input):
     content = input.read()
     return _run(content)
     
-# TODO think about how to get multiple errors
 def _run(buffer):
+    l = list(get_actions_error(buffer))
     syntax_error = get_syntax_error(buffer)
-    actions_error = get_actions_error(buffer)
-
     if syntax_error:
-        yield syntax_error
-    
-    if actions_error:
-        yield actions_error
+        l.append(syntax_error)
+    return l
 
 def get_syntax_error(buffer):
     assert hasattr(buffer, '__getitem__'), \
@@ -45,17 +39,15 @@ def get_syntax_error(buffer):
                            'syntax')
 
 ACTIONS_ERROR_RULES = [
+    rules.jobs_steps_uses,
     rules.event_trigger,
-    rules.steps_uses
     ]
 
 def get_actions_error(buffer):
     tokens = list(parser.tokenize(buffer))
     schema = get_workflow_schema(SCHEMA_FILE)
     for rule in ACTIONS_ERROR_RULES:
-        problem = rule.check(tokens, schema)
-        if problem:
-            return problem
+        yield rule.check(tokens, schema)
         
 def get_workflow_schema(file):
     with open(file) as f:

--- a/validateactions/linter.py
+++ b/validateactions/linter.py
@@ -21,6 +21,9 @@ def run(input):
     
 def _run(buffer):
     l = list(get_actions_error(buffer))
+    for problem in l:
+        if problem == None:
+            l.remove(problem)
     syntax_error = get_syntax_error(buffer)
     if syntax_error:
         l.append(syntax_error)

--- a/validateactions/rules/__init__.py
+++ b/validateactions/rules/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ['event_tigger', 'jobs_steps_uses']
+
+from . import event_trigger
+from . import jobs_steps_uses

--- a/validateactions/rules/event_trigger.py
+++ b/validateactions/rules/event_trigger.py
@@ -12,27 +12,34 @@ MATCHING_TOKENS = {
 }
 
 def check(tokens, schema):
-    on_index = find_index_of('on', yaml.ScalarToken, tokens)
-    if not on_index:
-        return LintProblem(0, 0, 'error', 'No on token found', rule)
-
-    structure_determining_token_index = on_index + 2
+    on_indices = list(find_index_of('on', yaml.ScalarToken, tokens))
+    if len(on_indices) == 1:
+        on_index = on_indices[0]
+        structure_determining_token_index = on_index + 2
+    elif not on_indices:
+        yield LintProblem(0, 0, 'error', 'No "on" token found', rule)
+        return
+    else:
+        yield LintProblem(0, 0, 'error', 'Multiple "on" tokens found', rule)
+        return
     structure = type(tokens[structure_determining_token_index])
+
+    events = parse_events_from_schema(schema)
 
     match structure:
         case yaml.ScalarToken:
-            return check_single_event(tokens, schema, structure_determining_token_index)
+            yield from check_single_event(tokens, events, structure_determining_token_index)
         case yaml.FlowSequenceStartToken:
-            yield from check_sequence(tokens, schema, structure_determining_token_index, MATCHING_TOKENS[structure])
+            yield from check_sequence(tokens, events, structure_determining_token_index, MATCHING_TOKENS[structure])
         case yaml.BlockSequenceStartToken:
-            yield from check_sequence(tokens, schema, structure_determining_token_index, MATCHING_TOKENS[structure])
+            yield from check_sequence(tokens, events, structure_determining_token_index, MATCHING_TOKENS[structure])
         case yaml.BlockMappingStartToken:
-            yield from check_mapping(tokens, schema, structure_determining_token_index, MATCHING_TOKENS[structure])
+            yield from check_mapping(tokens, events, structure_determining_token_index, MATCHING_TOKENS[structure])
         case yaml.FlowMappingStartToken:
             return # TODO
         case _:
             error_token = tokens[structure_determining_token_index]
-            return LintProblem(
+            yield LintProblem(
                 error_token.start_mark.line,
                 error_token.start_mark.column,
                 'error',
@@ -45,29 +52,29 @@ def find_on_index(tokens):
         if isinstance(token, yaml.ScalarToken) and token.value == 'on':
             return i
 
-def check_single_event(tokens, schema, structure_determining_token_index):
+def check_single_event(tokens, events, structure_determining_token_index):
     event_index = structure_determining_token_index
     token = tokens[event_index]
-    return check_scalar_against_schema(token, schema)
+    yield from check_scalar_against_schema(token, events)
 
-def check_sequence(tokens, schema, structure_determining_token_index, end_token):
+def check_sequence(tokens, events, structure_determining_token_index, end_token):
     i = structure_determining_token_index + 1
 
     token = tokens[i]
     while (not isinstance(token, end_token)):
         if isinstance(token, yaml.ScalarToken):
-            yield check_scalar_against_schema(token, schema)
+            yield from check_scalar_against_schema(token, events)
         i += 1
         token = tokens[i]
 
-def check_mapping(tokens, schema, structure_determining_token_index, end_token):
+def check_mapping(tokens, events, structure_determining_token_index, end_token):
     i = structure_determining_token_index + 1
 
     token = tokens[i]
-
+    
     while (not isinstance(token, end_token)):
         if isinstance(token, yaml.ScalarToken):
-            yield check_scalar_against_schema(token, schema)
+            yield from check_scalar_against_schema(token, events)
         elif type(token) in MATCHING_TOKENS.keys():
             brace_type = type(token)
             while (not isinstance(token, MATCHING_TOKENS[brace_type])):
@@ -77,13 +84,12 @@ def check_mapping(tokens, schema, structure_determining_token_index, end_token):
         i += 1
         token = tokens[i]
 
-def check_scalar_against_schema(token, schema):
-    events = parse_events_from_schema(schema)
+def check_scalar_against_schema(token, events):
     event = token
-    if not events.__contains__(event.value):
+    if not event.value in events:
         desc = f'event must be valid but found: "{event.value}"'
         level = 'error'
-        return LintProblem(
+        yield LintProblem(
             event.start_mark.line,
             event.start_mark.column,
             level,

--- a/validateactions/rules/jobs_steps_uses.py
+++ b/validateactions/rules/jobs_steps_uses.py
@@ -13,9 +13,20 @@ def check(tokens, schema):
         
         yield from not_using_version_spec(action_slug, action_index, tokens)
 
-        required_inputs, all_inputs = get_inputs(action_slug)
-        yield from check_required_inputs(action_index, tokens, action_slug, required_inputs)
-        yield from uses_non_defined_input(action_index, tokens, action_slug, all_inputs)
+        required_inputs, possible_inputs = get_inputs(action_slug)
+
+        with_index = action_index + 2
+        with_token = tokens[with_index]
+        with_exists = has_with(with_token)
+        if not with_exists:
+            if len(required_inputs) == 0:
+                break
+            else:
+                yield from misses_required_input(with_token, action_slug, required_inputs)
+        else:
+            used_inputs = list(get_used_inputs(tokens, with_index))
+            yield from check_required_inputs(with_token, used_inputs, action_slug, required_inputs)
+            yield from uses_non_defined_input(with_index, used_inputs, tokens, action_slug, possible_inputs)
 
 def get_uses_indices(tokens):
     for i, token in enumerate(tokens):
@@ -46,59 +57,55 @@ def get_inputs(action_slug):
             return [], []
 
         required_inputs = []
-        all_inputs = []
+        possible_inputs = []
         for input, required in action_schema['inputs'].items():
             if required == True:
                 required_inputs.append(input)
-                all_inputs.append(input)
+                possible_inputs.append(input)
             else:
-                all_inputs.append(input)
-        return required_inputs, all_inputs
+                possible_inputs.append(input)
+        return required_inputs, possible_inputs
 
-# region required inputs
-def check_required_inputs(action_index, tokens, action_slug, required_inputs):
-    if len(required_inputs) == 0:
-        return
-    
-    with_index = action_index + 2
-    yield from has_no_with(tokens[with_index], action_slug, required_inputs)
-    yield from has_wrong_with(tokens, with_index, action_slug, required_inputs)
+def has_with(token):
+    return isinstance(token, yaml.ScalarToken) and token.value == 'with'
 
-def has_no_with(token, action_slug, required_inputs):
-    if (
-        isinstance(token, yaml.ScalarToken) 
-        and token.value == 'with'
-    ):
-        return
-    yield return_missing_inputs_problem(token, action_slug, required_inputs)
-
-def has_wrong_with(tokens, with_index, action_slug, required_inputs):
-    used_inputs = get_used_inputs(tokens, with_index)
-    
-    for input in required_inputs:
-        if input not in used_inputs:
-            yield return_missing_inputs_problem(tokens[with_index], action_slug, required_inputs)
-
-def return_missing_inputs_problem(
+def misses_required_input(
         token: yaml.Token, 
         action_slug: str, 
-        required_inputs: list) -> LintProblem:
+        required_inputs: list) -> Iterator[LintProblem]:
     prettyprint_required_inputs = ', '.join(required_inputs)
-    return LintProblem(
+    yield LintProblem(
         token.start_mark.line,
         token.start_mark.column,
         'error',
         f'{action_slug} misses required inputs: {prettyprint_required_inputs}',
         rule
     )
-# endregion required inputs
 
-def uses_non_defined_input(action_index, tokens, action_slug, possible_inputs):
+def get_used_inputs(tokens, with_index):
+    i = with_index + 2
+    while not isinstance(tokens[i], yaml.BlockEndToken):
+        if (
+            isinstance(tokens[i], yaml.KeyToken)
+            and isinstance(tokens[i+1], yaml.ScalarToken)
+        ):
+            yield tokens[i+1].value
+            i += 3
+        i += 1
+
+def check_required_inputs(with_token, used_inputs, action_slug, required_inputs):
+    if len(required_inputs) == 0:
+        return
+            
+    for input in required_inputs:
+        if input not in used_inputs:
+            yield from misses_required_input(with_token, action_slug, required_inputs)    
+
+
+def uses_non_defined_input(with_index, used_inputs, tokens, action_slug, possible_inputs):
     if len(possible_inputs) == 0:
         return
-    
-    with_index = action_index + 2
-    used_inputs = get_used_inputs(tokens, with_index)
+
     i = 0
     j = 4
     for input in used_inputs:
@@ -110,15 +117,4 @@ def uses_non_defined_input(action_index, tokens, action_slug, possible_inputs):
                 f'{action_slug} has unknown input: {input}',
                 rule
             )
-        i += 1
-
-def get_used_inputs(tokens, with_index):
-    i = with_index + 2
-    while not isinstance(tokens[i], yaml.BlockEndToken):
-        if (
-            isinstance(tokens[i], yaml.KeyToken)
-            and isinstance(tokens[i+1], yaml.ScalarToken)
-        ):
-            yield tokens[i+1].value
-            i += 3
         i += 1

--- a/validateactions/rules/jobs_steps_uses.py
+++ b/validateactions/rules/jobs_steps_uses.py
@@ -18,15 +18,9 @@ def check(tokens, schema):
         yield from uses_non_defined_input(action_index, tokens, action_slug, all_inputs)
 
 def get_uses_indices(tokens):
-    index = 0
-    while True:
-        sub_tokens = tokens[index:]
-        found = find_index_of('uses', yaml.ScalarToken, sub_tokens)
-        if found == -1:
-            break
-        index += found
-        yield index
-        index += 1
+    for i, token in enumerate(tokens):
+        if isinstance(token, yaml.ScalarToken) and token.value == 'uses':
+            yield i
 
 def not_using_version_spec(
     action_slug: str,

--- a/validateactions/rules/support_functions.py
+++ b/validateactions/rules/support_functions.py
@@ -1,10 +1,7 @@
 import yaml
+from typing import Iterable
 
-def find_index_of(value: str, token_type: yaml.Token, tokens: list[yaml.Token]) -> int:
+def find_index_of(value: str, token_type: yaml.Token, tokens: list[yaml.Token]) -> Iterable[int]:
     for i, token in enumerate(tokens):
-        if not isinstance(token, token_type):
-            continue
-        if not token.value == value:
-            continue
-        return i
-    return -1
+        if isinstance(token, token_type) and token.value == value:
+            yield i


### PR DESCRIPTION
Refactor code to yield to enable parsing of multiple problems of a file:
- Refactor program structure to work with yield and multiple errors `validateactions/cli`, `validateactions/linter`
- Refactor `rules` to yield instead of return and thus allow multiple problems
- Refactor tests accordingly