### PR TITLE
Add functionality to fix missing action versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "validate-actions"
-version = "0.1.7"
+version = "0.1.8"
 description = "CLI for github actions workflow validation"
 authors = [
     {name = "konradhorber",email = "konrad.horber@gmail.com"}

--- a/validate_actions/rules/support_functions.py
+++ b/validate_actions/rules/support_functions.py
@@ -1,14 +1,15 @@
 
 import logging
-from typing import Iterable
+from pathlib import Path
+from typing import Dict, Iterable, Optional
 
 import requests
 import yaml
 
+from validate_actions.problems import Problem, ProblemLevel
 from validate_actions.workflow.ast import String
 
 # TODO fix and upgrade this mess
-
 
 
 def find_index_of(value: str, token_type: yaml.Token, tokens: list[yaml.Token]) -> Iterable[int]:
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 SESSION = requests.Session()
 GITHUB_URL = 'https://raw.githubusercontent.com/'
 
-same_session_cache = {}
+parse_action_cache = {}
 
 def parse_action(slug):
     if isinstance(slug, String):
@@ -31,10 +32,10 @@ def parse_action(slug):
 
     for current_tag in tags:
         url_no_ext = f'{GITHUB_URL}{action}/{current_tag}/action'
-        
-        if url_no_ext in same_session_cache:
-            return same_session_cache[url_no_ext]
-        
+
+        if url_no_ext in parse_action_cache:
+            return parse_action_cache[url_no_ext]
+
         for ext in ['.yml', '.yaml']:
             try:
                 response = SESSION.get(f'{url_no_ext}{ext}')
@@ -48,6 +49,66 @@ def parse_action(slug):
                 except yaml.YAMLError as e:
                     logger.error(f"Couldn't parse YAML of {action} download: {e}")
                     return
-                same_session_cache[url_no_ext] = action_metadata
+                parse_action_cache[url_no_ext] = action_metadata
                 return action_metadata
     return
+
+
+get_current_action_version_cache: Dict[str, str] = {}
+
+
+def get_current_action_version(slug: str) -> Optional[str]:
+    url = f'https://api.github.com/repos/{slug}/tags'
+    if url in get_current_action_version_cache:
+        return get_current_action_version_cache[url]
+
+    try:
+        response = SESSION.get(url)
+    except requests.RequestException as e:
+        logger.warning(f"Request error for {url}: {e}")
+
+    if response.status_code == 200:
+        try:
+            tags = response.json()
+            if tags:
+                latest_tag = tags[0]['name']
+                get_current_action_version_cache[url] = latest_tag
+                return latest_tag
+        except (ValueError, KeyError) as e:
+            logger.warning(f"Couldn't parse JSON response from {url}: {e}")
+
+    return None
+
+
+def edit_yaml_at_position(
+    file_path: Path,
+    idx: int,
+    num_delete: int,
+    new_text: str,
+    problem: Problem,
+    new_problem_desc: str
+) -> Problem:
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        if idx < 0 or idx >= len(content):
+            return problem
+
+        # Perform edit: delete and insert
+        updated_content = (
+            content[:idx] +
+            new_text +
+            content[idx + num_delete:]
+        )
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(updated_content)
+
+        problem.level = ProblemLevel.NON
+        problem.desc = new_problem_desc
+
+    except (OSError, ValueError, TypeError, UnicodeError):
+        return problem
+    finally:
+        return problem

--- a/validate_actions/workflow/ast.py
+++ b/validate_actions/workflow/ast.py
@@ -260,7 +260,7 @@ class Expression():
     parts: List['String']
 
 
-@dataclass(frozen=True)
+@dataclass
 class String:
     """Represents a string value along with its positional metadata."""
 

--- a/validate_actions/workflow/parser.py
+++ b/validate_actions/workflow/parser.py
@@ -560,7 +560,7 @@ class PyYAMLParser(YAMLParser):
         """
         Reads a token and returns a Pos object.
         """
-        return Pos(token.start_mark.line, token.start_mark.column)
+        return Pos(token.start_mark.line, token.start_mark.column, token.start_mark.index)
 
     def _parse_expressions(
         self,


### PR DESCRIPTION
- Enhanced `JobsStepsUses` rule to optionally add version specifications for actions as a fix
- Implemented `test_fix_missing_version_spec` to validate and fix missing action versions in workflows
- Refactored `edit_yaml_at_position` to generalize for all fix operations
- Added `get_current_action_version` to retrieve the most recent version of an action from GitHub
- Changed `String` class to a mutable dataclass for easier manipulation